### PR TITLE
Fix issue with expand after read causing tail to be set incorrectly

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ module.exports = function CircularBuffer(opts) {
 		if (buffer instanceof Buffer) self.copy(newBuffer);
 		buffer = newBuffer;
 		head = 0;
-		tail = self.length || 0;
+		tail = oldLength || 0;
 	}
 
 

--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@ module.exports = function CircularBuffer(opts) {
 
 	function setBuffer(newSize) {
 		// Add 1 byte of padding to the buffer to make the overall implementation easier
+		var oldLength = self.length;
 		var newBuffer = new Buffer(newSize + 1);
 		newBuffer.fill(0);
 		if (buffer instanceof Buffer) self.copy(newBuffer);
@@ -416,6 +417,7 @@ module.exports = function CircularBuffer(opts) {
 
 	this.toString = function toString(encoding) {
 		// The extra `toString` ensures that a string is returned even if `encoding === 'buffer'`.
+		if (encoding === 'hex') return this.peek(Infinity, 'buffer').toString('hex'); // Parity with Buffer.toString()
 		return this.peek(Infinity, encoding).toString();
 	};
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "author": "Chris Barrick <cbarrick1@gmail.com>",
   "license": "ISC",
   "devDependencies": {
-    "buffertools": "^2.1.2",
     "chai": "^1.9.1",
     "mocha": "^1.20.1"
   }


### PR DESCRIPTION
I've been using this extensively in my node-amqp-1-0 module to keep track of incoming data, and it's been incredibly useful.  However, this bug just bit me when I had a bunch of data coming in all at once, and reads wound up getting interleaved with expands - the "tail" gets set from self.length, which internally uses the "head" that's already been reassigned.  Just fetching the length before setting anything solved the problem - I tried to pull out a simple repro case.

I also altered toString to accept toString('hex'), which is immensely useful for me in debugging.

Thanks again for the great module, hope an unsolicited PR is ok :)
